### PR TITLE
Change cron logic to use /var/spool/crontabs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM kartoza/postgis:11.0-2.5
 MAINTAINER tim@kartoza.com
- 
+
 RUN apt-get -y update; apt-get install -y postgresql-client
-ADD backups-cron /etc/cron.d/backups-cron
 RUN touch /var/log/cron.log
-ADD backups.sh /backups.sh
-ADD restore.sh /restore.sh
-ADD start.sh /start.sh
 
-ENTRYPOINT []
-CMD ["/start.sh"]
+COPY backups-cron /backups-cron
+COPY backups.sh /backups.sh
+COPY restore.sh /restore.sh
+COPY start.sh /start.sh
 
+ENTRYPOINT ["/bin/bash", "/start.sh"]

--- a/backups-cron
+++ b/backups-cron
@@ -1,7 +1,7 @@
 # For testing - run every minute
-#*/1 * * * * root /backups.sh 2>&1
+*/1 * * * * /backups.sh 2>&1
 
 # Run the backups at 11pm each night
-0 23 * * * root /backups.sh 2>&1
+0 23 * * * /backups.sh 2>&1
 
 # We need a blank line here for it to be a valid cron file

--- a/start.sh
+++ b/start.sh
@@ -59,5 +59,6 @@ echo "Start script running with these environment options"
 set | grep PG
 
 # Now launch cron in then foreground.
+crontab /backups-cron
 
 cron -f


### PR DESCRIPTION
Change cron logic to use /var/spool/crontab as container crontab directory, as it wasn't running any `cron` job in a container before with on Ubuntu 18.04 and 

```
docker --version
Docker version 19.03.4, build 9013bf583a

docker-compose --version
docker-compose version 1.22.0, build f46880fe
```

fixes #24 