### PR TITLE
Add env variables DBLIST and REMOVE_BEFORE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A simple docker container that runs PostGIS backups. It is intended to be used
 primarily with our [docker postgis](https://github.com/kartoza/docker-postgis)
-docker image. By default it will create a backup once per night (at 23h00)in a 
+docker image. By default it will create a backup once per night (at 23h00)in a
 nicely ordered directory by year / month.
 
 * Visit our page on the docker hub at: https://registry.hub.docker.com/u/kartoza/pg-backup/
@@ -27,8 +27,8 @@ docker pull kartoza/pg-backup:9.4
 docker pull kartoza/pg-backup:9.3
 ```
 
-We highly suggest that you use a tagged image (9.6 currently available) as 
-latest may change and may not successfully back up your database. Use the same or 
+We highly suggest that you use a tagged image (9.6 currently available) as
+latest may change and may not successfully back up your database. Use the same or
 greater version of postgis as the database you are backing up.
 
 
@@ -57,14 +57,14 @@ docker run --name="backups"\
            -v backups:/backups \
            -i -d kartoza/pg-backup:9.4
 ```
-           
+
 In this example I used a volume into which the actual backups will be
 stored.
 
 ## Specifying environment
 
 
-You can also use the following environment variables to pass a 
+You can also use the following environment variables to pass a
 user name and password etc for the database connection.
 
 **Note:** These variable names were changed when updating to support our PG version 10 image so that the names used here are consistent with those used in the postgis v10 image.
@@ -75,6 +75,8 @@ user name and password etc for the database connection.
 * POSTGRES_HOST if not set, defaults to : db
 * POSTGRES_DBNAME if not set, defaults to : gis
 * ARCHIVE_FILENAME you can use your specified filename format here, default to empty, which means it will use default filename format.
+* DBLIST a space-separated list of databases to backup, e.g. `gis postgres`. Default is all databases.
+* REMOVE_BEFORE remove all old backups older than specified amount of days, e.g. `30` would only keep backup files younger than 30 days. Default: no files are ever removed.
 
 Example usage:
 
@@ -82,7 +84,7 @@ Example usage:
 docker run -e POSTGRES_USER=bob -e POSTGRES_PASS=secret -link db -i -d kartoza/pg-backup
 ```
 
-One other environment variable you may like to set is a prefix for the 
+One other environment variable you may like to set is a prefix for the
 database dumps.
 
 * DUMPPREFIX if not set, defaults to : PG
@@ -146,7 +148,7 @@ The backup archive would be something like:
 /backups/2019/February/PG_gis.13-February-2019.dmp
 ```
 
-If you specify `ARCHIVE_FILENAME` instead (default value is empty). The 
+If you specify `ARCHIVE_FILENAME` instead (default value is empty). The
 filename will be fixed according to this prefix.
 Let's assume `ARCHIVE_FILENAME=/backups/latest`
 The backup archive would be something like
@@ -163,13 +165,13 @@ You need to specify some environment variables first:
  * TARGET_DB: the db name to restore
  * WITH_POSTGIS: Kartoza specific, to generate POSTGIS extension along with the restore process
  * TARGET_ARCHIVE: the full path of the archive to restore
- 
+
  The restore script will delete the `TARGET_DB`, so make sure you know what you are doing.
  Then it will create a new one and restore the content from `TARGET_ARCHIVE`
- 
- If you specify these environment variable using docker-compose.yml file, 
+
+ If you specify these environment variable using docker-compose.yml file,
  then you can execute a restore process like this:
- 
+
  ```
  docker-compose exec dbbackup /restore.sh
  ```

--- a/backups.sh
+++ b/backups.sh
@@ -18,8 +18,7 @@ echo "Backup running to $MYBACKUPDIR" >> /var/log/cron.log
 #
 # Loop through each pg database backing it up
 #
-DBLIST=`psql -l | awk '$1 !~ /[+(|:]|Name|List|template|postgres/ {print $1}'`
-# echo "Databases to backup: ${DBLIST}" >> /var/log/cron.log
+#echo "Databases to backup: ${DBLIST}" >> /var/log/cron.log
 for DB in ${DBLIST}
 do
   echo "Backing up $DB"  >> /var/log/cron.log
@@ -29,11 +28,18 @@ do
   	FILENAME="${ARCHIVE_FILENAME}.${DB}.dmp"
   fi
   if [[  -f ${MYBASEDIR}/globals.sql ]]; then
-        rm ${MYBASEDIR}/globals.sql
-        pg_dumpall  --globals-only -f ${MYBASEDIR}/globals.sql
+    rm ${MYBASEDIR}/globals.sql
+    pg_dumpall  --globals-only -f ${MYBASEDIR}/globals.sql
   else
-        echo "Dump users and permisions"
-        pg_dumpall  --globals-only -f ${MYBASEDIR}/globals.sql
+    echo "Dump users and permisions"
+    pg_dumpall  --globals-only -f ${MYBASEDIR}/globals.sql
   fi
   pg_dump -Fc -f ${FILENAME}  ${DB}
 done
+
+if [ "${REMOVE_BEFORE:-}" ]; then
+  TIME_MINUTES=$((REMOVE_BEFORE * 24 * 60))
+
+  echo "Removing following backups older than ${REMOVE_BEFORE} days" >> /var/log/cron.log
+  find ${MYBASEDIR}/* -type f -mmin +${TIME_MINUTES} -delete &>> /var/log/cron.log
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ dbbackup:
     - ./backups:/backups
   environment:
     - DUMPPREFIX=watchkeeper
+    # List databases to back up; defaults to all
+    - "DBLIST=gis"
+    # Remove backups older than (in days)
+    - REMOVE_BEFORE=30
     - POSTGRES_HOST=db
     - POSTGRES_DBNAME=gis
     - POSTGRES_USER=docker

--- a/start.sh
+++ b/start.sh
@@ -36,6 +36,16 @@ if [ -z "${ARCHIVE_FILENAME}" ]; then
   ARCHIVE_FILENAME=
 fi
 
+# How old can files and dirs be before getting trashed? In minutes
+if [ -z "${REMOVE_BEFORE}" ]; then
+  REMOVE_BEFORE=
+fi
+
+# How old can files and dirs be before getting trashed? In minutes
+if [ -z "${DBLIST}" ]; then
+  DBLIST=`psql -l | awk '$1 !~ /[+(|:]|Name|List|template|postgres/ {print $1}'`
+fi
+
 # Now write these all to case file that can be sourced
 # by then cron job - we need to do this because
 # env vars passed to docker will not be available
@@ -54,6 +64,8 @@ export PGHOST=$POSTGRES_HOST
 export PGDATABASE=$POSTGRES_DBNAME
 export DUMPPREFIX=$DUMPPREFIX
 export ARCHIVE_FILENAME="${ARCHIVE_FILENAME}"
+export REMOVE_BEFORE=$REMOVE_BEFORE
+export DBLIST=\"$DBLIST\"
  " > /pgenv.sh
 echo "Start script running with these environment options"
 set | grep PG


### PR DESCRIPTION
From README:

- DBLIST a space-separated list of databases to backup, e.g. gis postgres. Default is all databases.
- REMOVE_BEFORE remove all old backups older than specified amount of days, e.g. 30 would only keep backup files younger than 30 days. Default: no files are ever removed.