### PR TITLE
add reference version 9.6 for postgresql-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM kartoza/postgis:9.6-2.4
 MAINTAINER tim@kartoza.com
  
-RUN apt-get -y update; apt-get install -y postgresql-client
+RUN apt-get -y update; apt-get install -y postgresql-client-9.6
 ADD backups-cron /etc/cron.d/backups-cron
 RUN touch /var/log/cron.log
 ADD backups.sh /backups.sh


### PR DESCRIPTION
When I did build the image in branch 9.6 come with psql version  9.6.19 installed,  I got pg_dump version 13.0 instead of 9.6. Hence dump file generated will raise an error when I restore to a container with psql and pg_dump version 9.6 in it.
```
$ docker exec  projecta-db-backups /bin/sh -c "pg_dump --version"
pg_dump (PostgreSQL) 13.0 (Debian 13.0-1.pgdg100+1)
```

This PR adds a version reference to postgresql-client in Dockerfile to ensure that the pg_dump installed is version 9.6.
```
$ docker exec projecta-db-backups /bin/sh -c "psql --version"
psql (PostgreSQL) 9.6.19
$ docker exec projecta-db-backups /bin/sh -c "pg_dump --version"
pg_dump (PostgreSQL) 9.6.19
```