### PR TITLE
Add PATH to pgenv for cron access to s3cmd

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -126,6 +126,7 @@ mkdir -p ${DEFAULT_EXTRA_CONF_DIR}
 cron_config
 
 echo "
+export PATH=\"${PATH}\"
 export EXTRA_CONF_DIR=\"${EXTRA_CONF_DIR}\"
 export STORAGE_BACKEND=\"${STORAGE_BACKEND}\"
 export ACCESS_KEY_ID=\"${ACCESS_KEY_ID}\"


### PR DESCRIPTION
resolve #59 by adding PATH environment variable to the generated `pgenv.sh` script