### PR TITLE
Fix "bad hour" crontab error

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -150,7 +150,7 @@ function cron_config() {
       # default value
 
       if [ -z "${CRON_SCHEDULE}" ]; then
-        export CRON_SCHEDULE='0 24 * * *'
+        export CRON_SCHEDULE='0 23 * * *'
       fi
       envsubst < /build_data/backups-cron > /backup-scripts/backups-cron
 


### PR DESCRIPTION
Running backups with the default `CRON_SCHEDULE` results in this error:

```
"/backup-scripts/backups-cron":1: bad hour
errors in crontab file, can't install.
```

The documentation says:

> ... once per night (at 23h00)

Thus changed the hour to 23 in the expression.

Issue: https://github.com/kartoza/docker-pg-backup/issues/108
Similar PR: https://github.com/kartoza/docker-pg-backup/pull/109