### PR TITLE
Bugfix to Dockerfile + restore.sh fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ARG POSTGIS_MAJOR_VERSION=3
 ARG POSTGIS_MINOR_RELEASE=5
 
 FROM kartoza/postgis:$POSTGRES_MAJOR_VERSION-$POSTGIS_MAJOR_VERSION.${POSTGIS_MINOR_RELEASE} AS postgis-backup-production
+ARG POSTGRES_MAJOR_VERSION
+ARG POSTGIS_MAJOR_VERSION
+ARG POSTGIS_MINOR_RELEASE
 
 RUN apt-get -y update; apt-get -y --no-install-recommends install  cron python3-pip vim  gettext \
     && apt-get -y --purge autoremove && apt-get clean \

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-
-#!/bin/bash
-
 source /backup-scripts/pgenv.sh
 POSTGRES_MAJOR_VERSION=$(cat /tmp/pg_version.txt)
 BIN_DIR="/usr/lib/postgresql/${POSTGRES_MAJOR_VERSION}/bin/"
@@ -33,7 +30,7 @@ else
 		BACKUP_URL=${MYBACKUPDIR}/${DUMPPREFIX}_${2}.${MYDATE}.dmp.gz
 		if [[ "$(s3cmd ls s3://${BACKUP_URL} | wc -l)" = 1 ]]; then 
 			s3cmd get s3://${BACKUP_URL} /data/dump/$2.dmp.gz
-    	gunzip /data/dump/$2.dmp.gz
+    	    gunzip /data/dump/$2.dmp.gz
 			echo "delete target DB with if its exists and recreate it"
 			export PGPASSWORD=${POSTGRES_PASS}
 			${BIN_DIR}/dropdb ${PG_CONN_PARAMETERS} --force --if-exists ${2}


### PR DESCRIPTION
Fix setting of ARGs, currently POSTGRES_MAJOR_VERSION would be empty, to use an ARG inside the build set it explicitly. 
see: https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact
If not set this way pg_version.txt will be empty and restore.sh from s3 will fail.

Also saw that the test-scenarios don't test restores, this bug was captured by manual testing. My motto: a backup is not real until a restore is attempted. 